### PR TITLE
Handle non-thrown 404 errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,9 @@ function error(opts) {
   return function *error(next){
     try {
       yield next;
+      // Handle 404 upstream.
+      var status = this.status || 404;
+      if (404 == status) this.throw(404);
     } catch (err) {
       this.status = err.status || 500;
 


### PR DESCRIPTION
Handles 404 errors when `this.status` is `undefined`.
Uses the same code applied in the `catch` and automatically applies the message derived from `this.throw`.
