### PR TITLE
Status code on default exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function error(opts) {
             response: this.response,
             error: err.message,
             stack: err.stack,
-            status: err.status,
+            status: this.status,
             code: err.code
           });
           break;


### PR DESCRIPTION
If `err.status` is falsy, `this.status` code is being set to 500, so it's the latter that should be passed to the template.
