### PR TITLE
pass more information to front-end

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,6 +43,13 @@ Here's an example:
       <h1>Error</h1>
     <p>Looks like something broke!</p>
     {% if env == 'development' %}
+      <h2>Message:</h2>
+      <pre>
+        <code>
+{{error}}
+        </code>
+      </pre>
+      <h2>Stack:</h2>
       <pre>
         <code>
 {{stack}}

--- a/error.html
+++ b/error.html
@@ -11,9 +11,19 @@
         font: 14px "Helvetica Neue", Helvetica, sans-serif;
       }
 
+      h1, h2 {
+        margin: 0;
+        padding: 10px 0;
+      }
+
       h1 {
         font-size: 2em;
-        margin-bottom: 5px;
+      }
+
+      h2 {
+        font-size: 1.2em;
+        font-weight: 200;
+        color: #aaa;
       }
 
       pre {
@@ -26,6 +36,13 @@
       <h1>Error</h1>
     <p>Looks like something broke!</p>
     {% if env == 'development' %}
+      <h2>Message:</h2>
+      <pre>
+        <code>
+{{error}}
+        </code>
+      </pre>
+      <h2>Stack:</h2>
       <pre>
         <code>
 {{stack}}


### PR DESCRIPTION
Realized we're not passing the error message to the front-end. This is pretty bad for lots of reasons, but it's especially awful for Jade errors.

**Before:**

![before](https://cldup.com/BKxSVC4ZGJ.png)

**After:**

![after](https://cldup.com/JByyc4dxfq.png)
