### PR TITLE
Support other templates besides Swig

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,12 +14,17 @@ $ npm install koa-error
 
 ## Options
 
- - `template` path to template written with [swig](http://paularmstrong.github.io/swig/)
+ - `render` function taking a single `locals` argument to render the template
+ - `template` path to template written with
+   `[Swig](http://paularmstrong.github.io/swig/) 
+   (if `render` function not provided)
+
+If you provide a Swig template, you must include `swig` in your dependencies.
 
 ## Custom templates
 
-  By using the `template` option you can override the bland default template,
-  with the following available local variables:
+  By using the `render` or `template` option you can override the bland default
+  template, with the following available local variables:
 
   - `env`
   - `ctx`
@@ -30,7 +35,7 @@ $ npm install koa-error
   - `status`
   - `code`
 
-Here's an example:
+Here's an example Swig template:
 
 ```html
 <!DOCTYPE html>

--- a/Readme.md
+++ b/Readme.md
@@ -14,12 +14,17 @@ $ npm install koa-error
 
 ## Options
 
+You have three options for rendering the error page:
+
+ - `view` a [koa-views](https://github.com/queckezz/koa-views) compatible view
+   name to be passed to `ctx.render(view, locals)`
  - `render` function taking a single `locals` argument to render the template
  - `template` path to template written with
    `[Swig](http://paularmstrong.github.io/swig/) 
-   (if `render` function not provided)
 
-If you provide a Swig template, you must include `swig` in your dependencies.
+Each option is attempted in the order listed. If you provide a Swig `template`,
+you must include `swig` in your dependencies. Likewise, if you provide a
+`view`, you must include the appropriate middleware.
 
 ## Custom templates
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 
-var swig = require('swig');
 var http = require('http');
 
 /**
@@ -24,8 +23,12 @@ function error(opts) {
   opts = opts || {};
 
   // template
-  var path = opts.template || __dirname + '/error.html';
-  var render = swig.compileFile(path);
+  var render = opts.render;
+  if (!render) {
+    var path = opts.template || __dirname + '/error.html';
+    var swig = require('swig');
+    render = swig.compileFile(path);
+  }
 
   // env
   var env = process.env.NODE_ENV || 'development';

--- a/index.js
+++ b/index.js
@@ -22,12 +22,15 @@ module.exports = error;
 function error(opts) {
   opts = opts || {};
 
-  // template
-  var render = opts.render;
-  if (!render) {
-    var path = opts.template || __dirname + '/error.html';
-    var swig = require('swig');
-    render = swig.compileFile(path);
+  // view or template
+  var view = opts.view;
+  if (!view) {
+    var render = opts.render;
+    if (!render) {
+      var path = opts.template || __dirname + '/error.html';
+      var swig = require('swig');
+      render = swig.compileFile(path);
+    }
   }
 
   // env
@@ -58,7 +61,7 @@ function error(opts) {
           break;
 
         case 'html':
-          this.body = render({
+          var locals = {
             env: env,
             ctx: this,
             request: this.request,
@@ -67,7 +70,9 @@ function error(opts) {
             stack: err.stack,
             status: this.status,
             code: err.code
-          });
+          };
+          if (view) return yield this.render(view, locals);
+          this.body = render(locals);
           break;
       }
     }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-error",
   "description": "Error reponses (text, json, html) for koa",
   "repository": "koajs/error",
-  "version": "1.1.3",
+  "version": "1.2.0-dev",
   "keywords": [
     "koa",
     "middleware",
@@ -14,10 +14,9 @@
     "error.html"
   ],
   "devDependencies": {
-    "koa": "koajs/koa"
+    "koa": "*"
   },
   "license": "MIT",
   "dependencies": {
-    "swig": "^1.3.2"
   }
 }


### PR DESCRIPTION
Added options:
- `render` for `render(locals)` rendering
- `view` for `yield this.render(view, locals)` rendering