### PR TITLE
Use lodash templates instead of swig

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ $ npm install koa-error
 ## Options
 
  - `template` path to template written with your template engine
- - `engine` template engine name passed to [consolidate](https://github.com/tj/consolidate.js), default: `swig`
+ - `engine` template engine name passed to [consolidate](https://github.com/tj/consolidate.js)
  - `cache` cached compiled functions, default: `NODE_ENV != 'development'`
 
 ## Custom templates
@@ -32,7 +32,41 @@ $ npm install koa-error
   - `status`
   - `code`
 
-Here's an example:
+Here are some examples:
+
+### Pug (formerly jade)
+
+```js
+app.use(error({
+  engine: 'pug',
+  template: __dirname + '/error.pug'
+}));
+```
+
+```jade
+doctype html
+html
+  head
+    title= 'Error - ' + status
+  body
+    #error
+      h1 Error
+      p Looks like something broke!
+      if env == 'development'
+        h2 Message:
+        pre: code= error
+        h2 Stack:
+        pre: code= stack
+```
+
+### Nunjucks
+
+```js
+app.use(error({
+  engine: 'nunjucks',
+  template: __dirname + '/error.njk'
+}));
+```
 
 ```html
 <!DOCTYPE html>

--- a/error.html
+++ b/error.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Error - {{status}}</title>
+    <title>Error - <%- status %></title>
     <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
     <style>
@@ -35,20 +35,20 @@
     <div id="error">
       <h1>Error</h1>
     <p>Looks like something broke!</p>
-    {% if env == 'development' %}
+    <% if (env === 'development') { %>
       <h2>Message:</h2>
       <pre>
         <code>
-{{error}}
+<%- error %>
         </code>
       </pre>
       <h2>Stack:</h2>
       <pre>
         <code>
-{{stack}}
+<%- stack %>
         </code>
       </pre>
-    {% endif %}
+    <% } %>
     </div>
   </body>
 </html>

--- a/examples/example.js
+++ b/examples/example.js
@@ -11,6 +11,7 @@ const koa = require('koa');
 const app = koa();
 
 app.use(error({
+  engine: 'lodash',
   template: join(__dirname, '../error.html')
 }));
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = error;
 function error(opts) {
   opts = opts || {};
 
-  const engine = opts.engine || 'swig'
+  const engine = opts.engine || 'lodash';
 
   // template
   const path = opts.template || __dirname + '/error.html';

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "error.html"
   ],
   "dependencies": {
-    "co-render": "1"
+    "co-render": "1",
+    "lodash": "4"
   },
   "devDependencies": {
     "ejs": "2",


### PR DESCRIPTION
This fixes #23 and #25.

- A lodash template is used as the default template
- koa-error now depends on lodash, so it is not missing when we try to render the default error template
- To encourage people to not depend on whatever the default engine happens to be at the moment:
  - The examples explicitly include an engine property and the readme no longer mentions the default engine used for the default template
  - The readme now has both a pug/jade and a nunjucks (a Jinja based template engine like swig) example to sample usage with two completely different type of template engines