### PR TITLE
Added guard for status code

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function error(opts) {
       await next();
       if (404 == ctx.response.status && !ctx.response.body) ctx.throw(404);
     } catch (err) {
-      ctx.status = err.status || 500;
+      ctx.status = 'number' == typeof err.status ? err.status : 500
 
       // application
       ctx.app.emit('error', err, ctx);

--- a/test/index.js
+++ b/test/index.js
@@ -42,4 +42,23 @@ describe('koa-error', () => {
     .expect(/\<title\>Error by ejs - 500\<\/title\>/)
     .end(done)
   })
+
+  it('ignores bad statuses', done => {
+    const app = new Koa();
+
+    app.use(error());
+
+    app.use(function (ctx){
+      const error = new Error('I have status');
+      error.status = 'This is broke';
+      throw error
+    });
+
+    request(app.listen())
+    .get('/')
+    .expect(500)
+    .expect('Content-Type', 'text/html; charset=utf-8')
+    .expect(/\<title\>Error - 500\<\/title\>/)
+    .end(done)
+  })
 })


### PR DESCRIPTION
Libraries that add a 'status' to their errors break this middleware.

Related: should we make sure the status code would be accepted by Koa? Should that be exposed by Koa so we don't reimplement the check?