### PR TITLE
Provide original error, which may contain custom properties.

### DIFF
--- a/error.html
+++ b/error.html
@@ -36,6 +36,13 @@
       <h1>Error</h1>
     <p>Looks like something broke!</p>
     <% if (env === 'development') { %>
+      <h2>Original error</h2>
+      <pre>
+        <code>
+<%- JSON.stringify(originalError, null, '  ') %>
+        </code>
+      </pre>
+
       <h2>Message:</h2>
       <pre>
         <code>

--- a/index.js
+++ b/index.js
@@ -61,14 +61,15 @@ function error (opts) {
 
         case 'json':
           ctx.type = 'application/json'
-          if (env === 'development') ctx.body = { error: err.message, stack: err.stack }
-          else if (err.expose) ctx.body = { error: err.message }
+          if (env === 'development') ctx.body = { error: err.message, stack: err.stack, originalError: err }
+          else if (err.expose) ctx.body = { error: err.message, originalError: err }
           else ctx.body = { error: http.STATUS_CODES[ctx.status] }
           break
 
         case 'html':
           ctx.type = 'text/html'
           ctx.body = await consolidate[engine](path, {
+            originalError: err,
             cache: cache,
             env: env,
             ctx: ctx,


### PR DESCRIPTION
I hesitated between calling it ```originalError``` and ```err```.

We now have access to all the error properties, if we called
```js
ctx.throw([status], [msg], [properties])
```
https://github.com/koajs/koa/blob/master/docs/api/context.md#ctxthrowstatus-msg-properties

Otherwise, ```error``` in the template is only the error message as a string.