### PR TITLE
Add options in opts for consolidate[engine]

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ $ npm install koa-error
 
  - `template` path to template written with your template engine
  - `engine` template engine name passed to [consolidate](https://github.com/tj/consolidate.js)
+ - `options` template engine options passed to [consolidate](https://github.com/tj/consolidate.js), [more-consolidate-options](https://github.com/tj/consolidate.js/blob/master/lib/consolidate.js)
  - `cache` cached compiled functions, default: `NODE_ENV != 'development'`
  - `env` force a NODE_ENV, default: `development`
  - `accepts` mimetypes passed to [ctx.accepts](https://github.com/koajs/koa/blob/master/docs/api/request.md#requestacceptstypes), default: `[ 'html', 'text', 'json' ]`

--- a/Readme.md
+++ b/Readme.md
@@ -99,6 +99,70 @@ app.use(error({
 </html>
 ```
 
+#### Custom filters, use macro,block in Nunjucks
+
+koa-error engine tool base on [consolidate](https://github.com/tj/consolidate.js), you can also set consolidate options 
+ 
+> [more-nunjucks-options](https://github.com/tj/consolidate.js/blob/master/lib/consolidate.js#L1317-L1370)
+
+`app.js`:
+
+```js
+//...
+const app = new Koa();
+const nunjucks = require('nunjucks');
+const nunjucksEnv = new nunjucks.Environment(new nunjucks.FileSystemLoader(path.join(__dirname, 'tpl')));
+
+// add filters
+const filters = require('./filters');
+for(let [k, v] of Object.entries(filters)){
+    nunjucksEnv.addFilter(k, v);
+}
+
+//...
+app.use(koaError({
+    //...
+    template: path.join(__dirname, 'tpl/error.html'),
+    options: {
+        nunjucksEnv // custom nunjucks env
+    }
+}));
+```
+
+`filters.js`:
+
+```js
+module.exports = { 
+    // define filters function here
+    stringify(..args){
+        return JSON.stringify(...args);
+    }
+    //...
+};
+```
+
+`tpl/error.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    {% include "./com.html" %}
+  </head>
+  <body>
+    <p>{{ request | stringify }}</p> {# use filters here #}
+    <!-- ... -->
+  </body>
+</htm>
+```
+
+`tpl/com.html`:
+
+```html
+<link rel="stylesheet" href="/css/normalize.css" />
+```
+
+
 ## License
 
   MIT

--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ function error (opts) {
 
   let { options } = opts
 
+  console.log(options)
+
   const engine = opts.engine || 'lodash'
 
   const accepts = opts.accepts || [ 'html', 'text', 'json' ]
@@ -70,7 +72,7 @@ function error (opts) {
 
         case 'html':
           ctx.type = 'text/html'
-          ctx.body = await consolidate[engine](path, {
+          ctx.body = await consolidate[engine](path, Object.assign({
             originalError: err,
             cache: cache,
             env: env,
@@ -80,9 +82,8 @@ function error (opts) {
             error: err.message,
             stack: err.stack,
             status: ctx.status,
-            code: err.code,
-            options: options
-          })
+            code: err.code
+          }, options))
           break
       }
     }

--- a/index.js
+++ b/index.js
@@ -29,8 +29,6 @@ function error (opts) {
 
   let { options } = opts
 
-  console.log(options)
-
   const engine = opts.engine || 'lodash'
 
   const accepts = opts.accepts || [ 'html', 'text', 'json' ]

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ module.exports = error
 function error (opts) {
   opts = opts || {}
 
+  let { options } = opts
+
   const engine = opts.engine || 'lodash'
 
   const accepts = opts.accepts || [ 'html', 'text', 'json' ]
@@ -78,7 +80,8 @@ function error (opts) {
             error: err.message,
             stack: err.stack,
             status: ctx.status,
-            code: err.code
+            code: err.code,
+            options: options
           })
           break
       }


### PR DESCRIPTION
If I wanna use `extend/include`, a `block`, `macro` or others in nunjuck, config such as follow: 

`Directory`:

```
   /
   ├─ app.js
   │
   └─ tpl
       │
       ├─ com.html
       │
       └─ error.html

```

`app.js`:

```js
app.use(koaError({
    //...
    engine: 'nunjucks',
    template: path.join(__dirname, 'tpl/error.html'),
    options: {
        settings: {
            views: path.join(__dirname, 'tpl') // use other tpl file in tpl
        },
        helpers: {
            stringify(o) {
                return JSON.stringify(o);
            }
        }
    }
}));
```

`tpl/error.html`:

```html
<!DOCTYPE html>
<html>
  <head>
    {% include "./com.html" %}
  </head>
  <body>
    <!--  use helpers.stringify(obj) here -->
    <!-- ... -->
  </body>
</htm>
```


`tpl/com.html`:

```html
<link rel="stylesheet" href="/css/normalize.css" />
```

[more-about-nunjucks](https://mozilla.github.io/nunjucks/templating.html#extends)

[issue-37](https://github.com/koajs/error/issues/37)